### PR TITLE
TR-2074 Add HTTPError to the DEP client newSession method

### DIFF
--- a/dep/client.go
+++ b/dep/client.go
@@ -170,7 +170,7 @@ func (c *Client) newSession() error {
 
 	// check resp statuscode
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(NewHTTPError(resp), "establishing DEP session")
+		return errors.Wrapf(NewHTTPError(resp), "establishing DEP session: %v", resp.Status)
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&authSessionToken); err != nil {

--- a/dep/client.go
+++ b/dep/client.go
@@ -170,7 +170,7 @@ func (c *Client) newSession() error {
 
 	// check resp statuscode
 	if resp.StatusCode != http.StatusOK {
-		return errors.Errorf("establishing DEP session: %v", resp.Status)
+		return errors.Wrap(NewHTTPError(resp), "establishing DEP session")
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&authSessionToken); err != nil {


### PR DESCRIPTION
This is a quick PR to solve an issue found in the functional tests. The errors when creating a new session were not returning the new HTTPError struct.